### PR TITLE
Enable CI run in main branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
     tags:
       - '*'
   pull_request:


### PR DESCRIPTION
Is best to have CI runs in the main branch, especially for something as testable as this library. 

Useful for if you merge a PR that wasn't quite up-to-date (i.e., the PR's pipeline passes, but it no longer passes after it's in main), and also for when you make commits right into main :) 