### PR TITLE
Create "check" GitHub Action for running tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,49 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  python-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install Python package
+        run: uv sync --all-extras --dev
+
+      - name: Run Python tests
+        run: uv run pytest
+
+      - name: Run Ruff linter
+        run: uv run ruff check .
+
+      - name: Run Ruff formatter check
+        run: uv run ruff format --check .
+
+      - name: Run Pyright type checker
+        run: uv run pyright .
+
+
+  rust-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Run Rust tests
+        run: cargo test --all


### PR DESCRIPTION
All pretty basic; nothing special.

An alternative would be to put this in the other CI workflow, which runs right before creating the distributions. Due to the dist script running on so many instruction sets/OSes though, I figured it made sense to have this one run in a separate job.

Note that the Python checks fail currently because there are pyright and ruff violations. 