### PR TITLE
Keep all columns when converting dataframe to geopandas

### DIFF
--- a/polars_st/geodataframe.py
+++ b/polars_st/geodataframe.py
@@ -340,11 +340,11 @@ class GeoDataFrameNameSpace:
         import geopandas as gpd
 
         return gpd.GeoDataFrame(
-            self._df.select(geom(geometry_name).st.to_shapely()).to_pandas(
+            self._df.with_columns(geom(geometry_name).st.to_shapely()).to_pandas(
                 use_pyarrow_extension_array=use_pyarrow_extension_array,
-                geometry=geometry_name,
                 **kwargs,
             ),
+            geometry=geometry_name,
         )
 
     @property

--- a/polars_st/geodataframe.py
+++ b/polars_st/geodataframe.py
@@ -340,12 +340,11 @@ class GeoDataFrameNameSpace:
         import geopandas as gpd
 
         return gpd.GeoDataFrame(
-            self._df.with_columns(geom(geometry_name).st.to_shapely()).to_pandas(
+            self.to_shapely(geometry_name).to_pandas(
                 use_pyarrow_extension_array=use_pyarrow_extension_array,
                 **kwargs,
             ),
             geometry=geometry_name,
-            crs=self._df.select(geom(geometry_name).st.srid())[0, 0],
         )
 
     @property

--- a/polars_st/geodataframe.py
+++ b/polars_st/geodataframe.py
@@ -345,6 +345,7 @@ class GeoDataFrameNameSpace:
                 **kwargs,
             ),
             geometry=geometry_name,
+            crs=self._df.select(geom(geometry_name).st.srid())[0, 0],
         )
 
     @property


### PR DESCRIPTION
Fixes dataframe `to_geopandas` method to keep all columns, closes #36 

Also keeps crs/srid information from polars-st when converting to geopandas.