### PR TITLE
Keep srid when converting to GeoPandas

### DIFF
--- a/polars_st/geodataframe.py
+++ b/polars_st/geodataframe.py
@@ -339,12 +339,24 @@ class GeoDataFrameNameSpace:
         """Convert this DataFrame to a geopandas GeoDataFrame."""
         import geopandas as gpd
 
+        if self._df.is_empty():
+            crs = None
+        else:
+            try:
+                crs = self._df.select(geom(geometry_name).st.srid()).unique().item()
+            except ValueError:
+                # Multiple SRIDs found
+                msg = "DataFrame with mixed SRIDs aren't supported in GeoPandas"
+                raise ValueError(msg)
+
+
         return gpd.GeoDataFrame(
             self.to_shapely(geometry_name).to_pandas(
                 use_pyarrow_extension_array=use_pyarrow_extension_array,
                 **kwargs,
             ),
             geometry=geometry_name,
+            crs=crs,
         )
 
     @property

--- a/polars_st/geodataframe.py
+++ b/polars_st/geodataframe.py
@@ -349,7 +349,6 @@ class GeoDataFrameNameSpace:
                 msg = "DataFrame with mixed SRIDs aren't supported in GeoPandas"
                 raise ValueError(msg)
 
-
         return gpd.GeoDataFrame(
             self.to_shapely(geometry_name).to_pandas(
                 use_pyarrow_extension_array=use_pyarrow_extension_array,

--- a/polars_st/geodataframe.py
+++ b/polars_st/geodataframe.py
@@ -340,11 +340,11 @@ class GeoDataFrameNameSpace:
         import geopandas as gpd
 
         return gpd.GeoDataFrame(
-            self._df.select(geom(geometry_name).st.to_shapely()).to_pandas(
+            self._df.with_columns(geom(geometry_name).st.to_shapely()).to_pandas(
                 use_pyarrow_extension_array=use_pyarrow_extension_array,
-                geometry=geometry_name,
                 **kwargs,
             ),
+            geometry=geometry_name,
         )
 
     @property

--- a/polars_st/geodataframe.py
+++ b/polars_st/geodataframe.py
@@ -340,12 +340,11 @@ class GeoDataFrameNameSpace:
         import geopandas as gpd
 
         return gpd.GeoDataFrame(
-            self._df.with_columns(geom(geometry_name).st.to_shapely()).to_pandas(
+            self.to_shapely(geometry_name).to_pandas(
                 use_pyarrow_extension_array=use_pyarrow_extension_array,
                 **kwargs,
             ),
             geometry=geometry_name,
-            crs=self._df.select(geom(geometry_name).st.srid())[0, 0],
         )
 
     @property

--- a/polars_st/geodataframe.py
+++ b/polars_st/geodataframe.py
@@ -339,13 +339,13 @@ class GeoDataFrameNameSpace:
         """Convert this DataFrame to a geopandas GeoDataFrame."""
         import geopandas as gpd
 
-        if self._df.is_empty():
-            crs = None
-        else:
-            try:
-                crs = self._df.select(geom(geometry_name).st.srid()).unique().item()
-            except ValueError:
-                # Multiple SRIDs found
+        srids = self._df.select(geom(geometry_name).st.srid()).unique().drop_nulls()
+        match len(srids):
+            case 0:
+                crs = None
+            case 1:
+                crs = srids.item()
+            case _:
                 msg = "DataFrame with mixed SRIDs aren't supported in GeoPandas"
                 raise ValueError(msg)
 

--- a/polars_st/geodataframe.py
+++ b/polars_st/geodataframe.py
@@ -345,6 +345,7 @@ class GeoDataFrameNameSpace:
                 **kwargs,
             ),
             geometry=geometry_name,
+            crs=self._df.select(geom(geometry_name).st.srid())[0, 0],
         )
 
     @property

--- a/tests/test_to_geopandas.py
+++ b/tests/test_to_geopandas.py
@@ -1,0 +1,51 @@
+import geopandas as gpd
+import polars as pl
+import pytest
+
+import polars_st as st
+
+
+@pytest.mark.parametrize("srid, expected_crs", [
+    (None, None),
+    (4326, "EPSG:4326"),
+])
+def test_to_geopandas_valid_conversion(srid, expected_crs):
+    wkts = ["POINT (0 0)", "POINT (1 2)"]
+    names = ["Foo", "Bar"]
+    gdf = st.GeoDataFrame({"geometry": wkts, "name": names})
+
+    if srid is not None:
+        gdf = gdf.with_columns(
+            pl.col("geometry").st.set_srid(srid)
+        )
+
+    geopandas_gdf = gdf.st.to_geopandas()
+
+    assert isinstance(geopandas_gdf, gpd.GeoDataFrame)
+    assert list(geopandas_gdf.geometry.to_wkt()) == wkts
+    assert list(geopandas_gdf["name"]) == names
+    assert geopandas_gdf.crs == expected_crs
+
+
+def test_to_geopandas_empty_dataframe():
+    gdf = st.GeoDataFrame({"geometry": []})
+    geopandas_gdf = gdf.st.to_geopandas()
+
+    assert isinstance(geopandas_gdf, gpd.GeoDataFrame)
+    assert geopandas_gdf.empty
+
+
+def test_to_geopandas_mixed_srids():
+    gdf = st.GeoDataFrame({
+        "geometry": ["POINT(0 0)", "POINT(1 2)"],
+        "srid": [4326, 3857],
+    }).with_columns(pl.col("geometry").st.set_srid("srid"))
+    with pytest.raises(
+            ValueError, match="DataFrame with mixed SRIDs aren't supported in GeoPandas"
+    ):
+        gdf.st.to_geopandas()
+
+
+def test_to_geopandas_no_geometry_column():
+    with pytest.raises(ValueError, match="geometry column geometry not found"):
+        st.GeoDataFrame({"name": ["Foo", "Bar"]})


### PR DESCRIPTION
Closes #38 

This now handles empty dataframes and mixed srid geometry columns. 

Since GeoPandas does not support mixed crs, I think it makes sense to raise an error informing the user of this so they can decide what to do. I considered adding logic in to automatically convert the geometry into a single srid, but the first pass felt a little clunky. 