### PR TITLE
Set geometry_type=None when geometry_name is None

### DIFF
--- a/polars_st/geodataframe.py
+++ b/polars_st/geodataframe.py
@@ -474,7 +474,7 @@ class GeoDataFrameNameSpace:
             arrow_obj = self._df.with_columns(geometry).to_arrow()
         else:
             arrow_obj = self._df.to_arrow()
-            geometry_type = "Unknown"
+            geometry_type = None  # If geometry_name is None, geometry_type must also be None
 
         write_arrow(
             arrow_obj,


### PR DESCRIPTION
When geometry_name is None, we now pass geometry_type=None so that pyogrio.write_arrow can write attribute-only layers without requiring a geometry column.