### PR TITLE
Fix fast path for sjoin

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1948,10 +1948,15 @@ impl SIndex {
             if right_geom.geometry_type()? == Point {
                 let x = right_geom.get_x()?;
                 let y = right_geom.get_y()?;
+                let right_geom_prepared = right_geom.to_prepared_geom()?;
                 for hit in self.tree.neighbors(x, y, None, Some(distance * distance)) {
-                    let (left_index, _) = &self.data[hit as usize];
-                    left_indices.push(*left_index as _);
-                    right_indices.push(right_index as _);
+                    let (left_index, left_geom) = &self.data[hit as usize];
+                    if left_geom.geometry_type()? == Point
+                        || right_geom_prepared.dwithin(left_geom, distance)?
+                    {
+                        left_indices.push(*left_index as _);
+                        right_indices.push(right_index as _);
+                    }
                 }
                 return Ok((left_indices, right_indices));
             }

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -439,7 +439,21 @@ def test_sjoin_dwithin_point_fast_path():
     """Sjoin dwithin must match when the right geometry is a Point (#66)."""
     left = st.GeoDataFrame(["POLYGON ((0 0, 90 0, 90 90, 0 90, 0 0))"])
     right = st.GeoDataFrame(["POINT (-5 -5)"])
+
     result = left.st.sjoin(right, predicate="dwithin", distance=math.hypot(5, 5))
     assert len(result) == 1
+    result = right.st.sjoin(left, predicate="dwithin", distance=math.hypot(5, 5))
+    assert len(result) == 1
+
     result = left.st.sjoin(right, predicate="dwithin", distance=math.hypot(5, 5) - 0.1)
     assert len(result) == 0
+    result = right.st.sjoin(left, predicate="dwithin", distance=math.hypot(5, 5) - 0.1)
+    assert len(result) == 0
+
+def test_sjoin_dwithin_one_point_one_not():
+    x = st.GeoDataFrame(['POINT (155719066 205491417)'])
+    y = st.GeoDataFrame(['POLYGON ((155716344.87878543 205492936.71299925, 155719224.59470508 205493723.593793, 155719440.83437797 205492891.7208944, 155718128.48325974 205492549.01458675, 155718291.78149548 205491748.72499204, 155718446.8775367 205490948.43069667, 155718603.46488604 205490136.644121, 155718082.25270897 205489999.75038928, 155717862.28476587 205490985.76510447, 155716642.39474916 205491625.23491108, 155716344.87878543 205492936.71299925))'])
+    assert x.st.sjoin(y, predicate = "dwithin", distance = 600).height == 0
+    assert y.st.sjoin(x, predicate = "dwithin", distance = 600).height == 0
+    assert x.st.sjoin(y, predicate = "dwithin", distance = 700).height == 1
+    assert y.st.sjoin(x, predicate = "dwithin", distance = 700).height == 1


### PR DESCRIPTION
The current fast path for sjoin doesn't work - it doesn't account for the fact that even if the right geometry is a point, the indexed (left) geometries may not be, in which case bbox-to-point distance ≠ geometry distance and you still need to call dwithin.

The test case is one where the point falls inside the polygon's bounding box, so the bbox-to-point distance is 0 and the distance² filter in self.tree.neighbors(x, y, None, Some(distance * distance)) is trivially satisfied — every candidate is admitted with no real verification.

In the PR I've fixed the fast path, but I think removing it entirely would be a better idea.